### PR TITLE
Update Chainer MNIST sample to use FixedTrial

### DIFF
--- a/examples/chainer_simple/src/chainer_simple.py
+++ b/examples/chainer_simple/src/chainer_simple.py
@@ -185,6 +185,7 @@ if __name__ == '__main__':
         print('    {}: {}'.format(key, value))
 
     # resave the best model
+    from optuna.trial import FixedTrial
     try:
         model = L.Classifier(create_model(FixedTrial(trial.params)))
         serializers.load_npz(os.path.join('/tmp', 'model_{}.npz'.format(trial.number)), model)

--- a/examples/chainer_simple/src/chainer_simple.py
+++ b/examples/chainer_simple/src/chainer_simple.py
@@ -138,7 +138,6 @@ if __name__ == '__main__':
     parser.add_argument('--n-trials', type=int, default=10)
 
     # Data, model, and output directories These are required.
-    parser.add_argument('--output-dir', type=str, default=os.environ['SM_OUTPUT_DIR'])
     parser.add_argument('--model-dir', type=str, default=os.environ['SM_MODEL_DIR'])
     parser.add_argument('--train', type=str, default=os.environ['SM_CHANNEL_TRAIN'])
     parser.add_argument('--test', type=str, default=os.environ['SM_CHANNEL_TEST'])
@@ -159,7 +158,6 @@ if __name__ == '__main__':
     train = chainer.datasets.TupleDataset(train_data, train_labels)
     test = chainer.datasets.TupleDataset(test_data, test_labels)
 
-    output_dir = args.output_dir
     model_dir = args.model_dir
     
     # Define an Optuna study. 
@@ -187,12 +185,12 @@ if __name__ == '__main__':
         print('    {}: {}'.format(key, value))
 
     # resave the best model
-    try: 
-        model = L.Classifier(load_model(trial.params))
+    try:
+        model = L.Classifier(create_model(FixedTrial(trial.params)))
         serializers.load_npz(os.path.join('/tmp', 'model_{}.npz'.format(trial.number)), model)
         serializers.save_npz(os.path.join(model_dir, 'model.npz'), model)        
         np.savez(os.path.join(model_dir, 'params.npz'), trial.params)
         
         print('    Saved:')
-    except: 
-        print('    Save failed.')
+    except Exception as e: 
+        print('    Save failed:', e)

--- a/examples/chainer_simple/src/chainer_simple.py
+++ b/examples/chainer_simple/src/chainer_simple.py
@@ -192,6 +192,6 @@ if __name__ == '__main__':
         serializers.save_npz(os.path.join(model_dir, 'model.npz'), model)        
         np.savez(os.path.join(model_dir, 'params.npz'), trial.params)
         
-        print('    Saved:')
+        print('    Model saved:', 'model_{}.npz'.format(trial.number))
     except Exception as e: 
         print('    Save failed:', e)

--- a/examples/chainer_simple/src/chainer_simple.py
+++ b/examples/chainer_simple/src/chainer_simple.py
@@ -48,18 +48,6 @@ def create_model(trial):
 
     return chainer.Sequential(*layers)
 
-def load_model(params):
-    n_layers = params['n_layers'] 
-
-    layers = []
-    for i in range(n_layers):
-        n_units = int(params['n_units_l{}'.format(i)])
-        layers.append(L.Linear(None, n_units))
-        layers.append(F.relu)
-    layers.append(L.Linear(None, 10))
-
-    return chainer.Sequential(*layers)
-
 def create_optimizer(trial, model):
     # We optimize the choice of optimizers as well as their parameters.
     optimizer_name = trial.suggest_categorical('optimizer', ['Adam', 'MomentumSGD'])
@@ -130,9 +118,11 @@ def model_fn(model_dir):
     https://github.com/aws/sagemaker-chainer-containers
     """
     
+    from optuna.trial import FixedTrial
+    
     chainer.config.train = False
     params = np.load(os.path.join(model_dir, 'params.npz'))['arr_0'].item()
-    model = L.Classifier(load_model(params))
+    model = L.Classifier(create_model(FixedTrial(params)))
     serializers.load_npz(os.path.join(model_dir, 'model.npz'), model)
     return model.predictor
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Chainer MNIST example is updated. [Loading the trained model](https://github.com/aws-samples/amazon-sagemaker-optuna-hpo-blog/blob/b57b544a89f6eee35a83fa68acbd64bbf3021a6b/examples/chainer_simple/src/chainer_simple.py#L135) in `model_fn` for serving is written with [optuna.trial.FixedTrial](https://optuna.readthedocs.io/en/latest/reference/trial.html#optuna.trial.FixedTrial). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
