### PR TITLE
Use absolute path in lifecycle config

### DIFF
--- a/template/generate-lifecycle-config-base64.py
+++ b/template/generate-lifecycle-config-base64.py
@@ -1,6 +1,6 @@
 import base64
 content = base64.b64encode(b"""#!/bin/bash
 sudo -u ec2-user -i <<'EOF'
-cd SageMaker && git clone https://github.com/aws-samples/amazon-sagemaker-optuna-hpo-blog.git
+cd /home/ec2-user/SageMaker && git clone https://github.com/aws-samples/amazon-sagemaker-optuna-hpo-blog.git
 EOF""")
 print(content)

--- a/template/optuna-template.yaml
+++ b/template/optuna-template.yaml
@@ -431,7 +431,7 @@ Resources:
     Properties:
       NotebookInstanceLifecycleConfigName: clone-optuna-sample-repository
       OnCreate:
-        - Content: IyEvYmluL2Jhc2gKc3VkbyAtdSBlYzItdXNlciAtaSA8PCdFT0YnCmNkIFNhZ2VNYWtlciAmJiBnaXQgY2xvbmUgaHR0cHM6Ly9naXRodWIuY29tL2F3cy1zYW1wbGVzL2FtYXpvbi1zYWdlbWFrZXItb3B0dW5hLWhwby1ibG9nLmdpdApFT0Y=
+        - Content: IyEvYmluL2Jhc2gKc3VkbyAtdSBlYzItdXNlciAtaSA8PCdFT0YnCmNkIC9ob21lL2VjMi11c2VyL1NhZ2VNYWtlciAmJiBnaXQgY2xvbmUgaHR0cHM6Ly9naXRodWIuY29tL2F3cy1zYW1wbGVzL2FtYXpvbi1zYWdlbWFrZXItb3B0dW5hLWhwby1ibG9nLmdpdApFT0Y=
 Outputs:
   VPC:
     Description: A reference to the created VPC


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Use absolute path in the lifecycle configuration because CreateNotebookInstance fails in some environments. 
https://github.com/aws-samples/amazon-sagemaker-optuna-hpo-blog/blob/master/template/generate-lifecycle-config-base64.py#L4

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
